### PR TITLE
Bearings

### DIFF
--- a/backend-api/armaps/api/directions.py
+++ b/backend-api/armaps/api/directions.py
@@ -258,7 +258,7 @@ def get_directions(venueid_url_slug, destid_url_slug):
     starting_waypoint = graph.insert_user_location(lat, lon)
     data = graph.get_path(starting_waypoint, destid_url_slug)
     correct_data = path_correction(data, (lat, lon))
-    data =  get_bearings(data)
+    correct_data =  get_bearings(correct_data)
 
     # Calculate distance to destination and time estimate, given path
     distance_to_dest, time_estimate = calculate_vars(correct_data, lat, lon)


### PR DESCRIPTION
Added code to directions get bearing from each waypoint to the next. To remove this functionality, comment out line 261 in directions.py. This code will cause each waypoint's data to return in the format:
{
    'lat': x,
    'lon': y,
    'id': z,
    'bearing': w
}
